### PR TITLE
Feat/sned response to client

### DIFF
--- a/inc/Request.hpp
+++ b/inc/Request.hpp
@@ -70,6 +70,8 @@ class Request
 	e_phase getPhase() const; 
 	int getFd() const; 
 
+	void reset();
+
   protected:
 
   private:

--- a/inc/Response.hpp
+++ b/inc/Response.hpp
@@ -22,6 +22,8 @@ class Response
 	{
 		IO_ERROR,
 		IO_DISCONNECT,
+		O_NOT_READY,
+		O_INCOMPLETE,
 		IO_SUCCESS,
 	};
 
@@ -46,6 +48,7 @@ class Response
 	bool isComplete() const;
 	void setEndCGI();
 	e_IOReturn retrieve();
+	e_IOReturn sendData(int fd);
 
 	std::string createResponseLine(Request const &request, std::string const & reason = "");
 	
@@ -62,8 +65,6 @@ class Response
 	std::string _cgiData;
 	int _cgiFd;
 	pid_t _cgiPid;
-	bool _cgiFinished;
-	bool _responseComplete;
 	ResponseLine _responseLine;
 	std::string _headers;
 	WebServer::Server _serverBlock;

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -144,6 +144,11 @@ int Request::getFd() const
 	return _fd;
 }
 
+void Request::reset()
+{
+	_phase = PHASE_EMPTY;
+	_statusCode = NONE;
+}
 
 // --- Private --- //
 

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -148,10 +148,17 @@ Response::e_IOReturn Response::retrieve()
 	char buffer[MAX_BUFFER_LEN + 1];
 	ssize_t bytes = recv(_cgiFd, buffer, MAX_BUFFER_LEN, 0);
 	if (bytes == -1)
+	{
+		_cgiData = "Status: 500 Internal Server Error\r\n";
 		return IO_ERROR;
+	}
 
 	if (bytes == 0)
+	{
+		if (_cgiData.empty())
+			_cgiData = "Status: 500 Internal Server Error\r\n";
 		return IO_DISCONNECT;
+	}
 
 	buffer[bytes] = '\0';
 

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -149,14 +149,14 @@ Response::e_IOReturn Response::retrieve()
 	ssize_t bytes = recv(_cgiFd, buffer, MAX_BUFFER_LEN, 0);
 	if (bytes == -1)
 	{
-		_cgiData = "Status: 500 Internal Server Error\r\n";
+		_cgiData = "Status: 500 Internal Server Error\n";
 		return IO_ERROR;
 	}
 
 	if (bytes == 0)
 	{
 		if (_cgiData.empty())
-			_cgiData = "Status: 500 Internal Server Error\r\n";
+			_cgiData = "Status: 500 Internal Server Error\n";
 		return IO_DISCONNECT;
 	}
 
@@ -434,7 +434,7 @@ void Response::parseCGIResponse()
 {
 	t_mapStrings cgiHeaders;
 	std::size_t pos = _cgiData.find("\n");
-	while (pos != 0)
+	while (pos != string::npos && pos != 0)
 	{
 		string headerLine = _cgiData.substr(0, pos);
 		_cgiData.erase(_cgiData.begin(), _cgiData.begin() + pos + 1);
@@ -447,7 +447,10 @@ void Response::parseCGIResponse()
 		}
 		pos = _cgiData.find("\n");
 	}
-	_cgiData.erase(_cgiData.begin(), _cgiData.begin() + pos + 1);
+	if (pos != string::npos)
+		_cgiData.erase(_cgiData.begin(), _cgiData.begin() + pos + 1);
+	else
+		_cgiData.erase(_cgiData.begin(), _cgiData.end());
 	if (cgiHeaders.find("Status") != cgiHeaders.end())
 	{
 		_buffer = "HTTP/1.1 " + cgiHeaders["Status"] + "\r\n";


### PR DESCRIPTION
There is a local variable that has the same name as _buffer, it should not be used as local variable but as member of the class.
It is missing the header Content-Length, it is the size of the body message.
getDefaultHeaders() should have 0 parameter, we don't need the request at all because the version doesn't depend on the request but is hardcoded.